### PR TITLE
Fix hyperlink color in custom-block classes

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -17,3 +17,6 @@ a > .icon.outbound {
   border: 1px solid var(--accentColor);
 }
 
+.custom-block a {
+  color: var(--accentColor) !important;
+}


### PR DESCRIPTION
### Eisen:

* [x] Heb je gecontroleerd of er nog geen andere pull request zijn die hetzelfde doen?
* [x] Is de tekst volledig grammaticaal correct?
* [x] Heb je je aanpassingen in een aparte branch gedaan?
  * Als niet, waarom?:


<!-- Leg hieronder uit wat jouw pull request oplost / toevoegt. -->
Hyperlinks in custom-blocks (zoals tip blocks) krijgen nu de goede text color.
Voor pullrequest:
![hyperlink heeft geen speciale kleur](https://user-images.githubusercontent.com/24954095/103036723-b6c2c600-456a-11eb-889e-6dcb6c1c7c90.png)
Na pullrequest:
![hyperlink heeft nu groene kleur](https://user-images.githubusercontent.com/24954095/103036894-0a351400-456b-11eb-9d70-e0f75d724ad7.png)

